### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,10 @@ Pillow
 numpy
 PyObjC
 opencv-contrib-python
-Wikipedia-API
 pytesseract
 google-cloud-vision
 nltk
 beautifulsoup4
 Vocabulary
-nltk
 lxml
+Wikipedia-API


### PR DESCRIPTION
Calling for nltk 2 times and Wikipedia-API should be called last

by putting Wikipedia-API last it gets rid of the:

"Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/2p/1kcpndps1g5c3p0x20qkm9lc0000gn/T/pip-build-rnn7v12k/Wikipedia-API/" 

error and also fixes the command from the run stop error.